### PR TITLE
Add requirements file and instructions for local scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,15 @@ Every day at 02:00 UTC, the system:
 - Alchemy API key for UniChain RPC access
 - Actual pool addresses (placeholders in SPEC need updating)
 
+## 🛠️ Running Scripts Locally
+
+If you need to run the Python scripts outside of Docker, install the required
+packages first:
+
+```bash
+pip install -r requirements.txt
+```
+
 ## 🎯 Success Criteria
 
 ✅ **Implemented Features:**

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+psycopg2-binary
+requests


### PR DESCRIPTION
## Summary
- add `requirements.txt`
- document how to install Python requirements when running scripts outside Docker

## Testing
- `python3 -m py_compile scripts/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6848ecd4c4bc8331916e20b4e6d9a8a6