### PR TITLE
Improve env docs and checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ UniChain RPC → HyperIndex → Postgres → ETL Scripts → CSV → Dune
    cp .env.template .env
    # Edit .env with your Alchemy RPC URLs and actual pool addresses
    ```
+   **Important**: set `HOOKED_POOL`, `STATIC_POOL`, `RPC_URL` and `RPC_WS` to real
+   values before starting the stack. The placeholders in `.env.template` will
+   cause the pipeline to fail.
 
 2. **Start Services**
    ```bash
@@ -87,6 +90,9 @@ Every day at 02:00 UTC, the system:
 - Docker & Docker Compose
 - Alchemy API key for UniChain RPC access
 - Actual pool addresses (placeholders in SPEC need updating)
+- The environment variables `HOOKED_POOL`, `STATIC_POOL`, `RPC_URL` and
+  `RPC_WS` **must** be filled in with real values in your `.env` file
+  before running `docker compose up`.
 
 ## 🎯 Success Criteria
 

--- a/scripts/daily_refresh.sh
+++ b/scripts/daily_refresh.sh
@@ -7,6 +7,30 @@ set -e  # Exit on any error
 echo "🌅 Starting daily refresh at $(date)"
 echo "======================================"
 
+# Warn if any environment variable still uses placeholder values
+warn_placeholders() {
+    local flagged=0
+    if [ "${HOOKED_POOL}" = "0x4107...e1f" ]; then
+        echo "⚠️  HOOKED_POOL uses placeholder address" >&2
+        flagged=1
+    fi
+    if [ "${STATIC_POOL}" = "0x51f9...3496e" ]; then
+        echo "⚠️  STATIC_POOL uses placeholder address" >&2
+        flagged=1
+    fi
+    if [[ "${RPC_URL}" == *"YOUR_ALCHEMY_KEY_HERE"* ]]; then
+        echo "⚠️  RPC_URL contains placeholder API key" >&2
+        flagged=1
+    fi
+    if [[ "${RPC_WS}" == *"YOUR_ALCHEMY_KEY_HERE"* ]]; then
+        echo "⚠️  RPC_WS contains placeholder API key" >&2
+        flagged=1
+    fi
+    [ $flagged -eq 1 ] && echo "🚨 Please update your .env file with real values." >&2
+}
+
+warn_placeholders
+
 # Database connection parameters
 DB_HOST=${PGHOST:-postgres}
 DB_PORT=${PGPORT:-5432}  

--- a/scripts/init_schema.sh
+++ b/scripts/init_schema.sh
@@ -6,6 +6,30 @@ set -e  # Exit on any error
 
 echo "🚀 Initializing database schema for UniChain WBTC/ETH swap fact pipeline..."
 
+# Warn if any environment variable still uses placeholder values
+warn_placeholders() {
+    local flagged=0
+    if [ "${HOOKED_POOL}" = "0x4107...e1f" ]; then
+        echo "⚠️  HOOKED_POOL uses placeholder address" >&2
+        flagged=1
+    fi
+    if [ "${STATIC_POOL}" = "0x51f9...3496e" ]; then
+        echo "⚠️  STATIC_POOL uses placeholder address" >&2
+        flagged=1
+    fi
+    if [[ "${RPC_URL}" == *"YOUR_ALCHEMY_KEY_HERE"* ]]; then
+        echo "⚠️  RPC_URL contains placeholder API key" >&2
+        flagged=1
+    fi
+    if [[ "${RPC_WS}" == *"YOUR_ALCHEMY_KEY_HERE"* ]]; then
+        echo "⚠️  RPC_WS contains placeholder API key" >&2
+        flagged=1
+    fi
+    [ $flagged -eq 1 ] && echo "🚨 Please update your .env file with real values." >&2
+}
+
+warn_placeholders
+
 # Database connection parameters
 DB_HOST=${PGHOST:-postgres}
 DB_PORT=${PGPORT:-5432}


### PR DESCRIPTION
## Summary
- document required env vars in README
- warn if placeholders are used at pipeline start

## Testing
- `bash -n scripts/daily_refresh.sh`
- `bash -n scripts/init_schema.sh`


------
https://chatgpt.com/codex/tasks/task_e_6848ecd66890833184d23dc1f425cab3