### PR TITLE
Clarify env file usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,9 @@ UniChain RPC → HyperIndex → Postgres → ETL Scripts → CSV → Dune
    cp .env.template .env
    # Edit .env with your Alchemy RPC URLs and actual pool addresses
    ```
-   **Important**: set `HOOKED_POOL`, `STATIC_POOL`, `RPC_URL` and `RPC_WS` to real
-   values before starting the stack. The placeholders in `.env.template` will
+   Docker Compose reads variables from `.env`; the `.env.template` file is only
+   a starting point. Set `HOOKED_POOL`, `STATIC_POOL`, `RPC_URL` and `RPC_WS` to
+   real values before starting the stack. Leaving placeholders in `.env` will
    cause the pipeline to fail.
 
 2. **Start Services**

--- a/SPEC.md
+++ b/SPEC.md
@@ -132,7 +132,7 @@ repo/
 │   ├─ export_to_csv.sh         # Exports the fact table to a CSV
 │   └─ daily_refresh.sh         # The main daily cron script
 ├─ docker-compose.yml
-├─ .env.template
+├─ .env.template        # sample values to copy into `.env`
 └─ README.md
 ```
 
@@ -154,7 +154,8 @@ CHAIN_ID=11877
 HOOKED_POOL="0x4107…e1f"
 STATIC_POOL="0x51f9…3496e"
 ```
-> `.env.template` is version-controlled; `.env` is git-ignored.
+> `.env.template` is version-controlled as a reference. Copy it to `.env` and
+> update the values. The runtime services read variables from `.env`.
 
 ---
 


### PR DESCRIPTION
## Summary
- clarify `.env` is the runtime env file
- note `.env.template` is only a reference

## Testing
- `docker compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848fb49b228833185acde777afba3d9